### PR TITLE
feat: 인증 방식 변경(cookie -> Auth Header)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev-msw": "VITE_MSW_ENABLED=true vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/src/components/layout/sidebar-components/UserProfile.tsx
+++ b/src/components/layout/sidebar-components/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { Building2, Shield } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/stores';
 
 import { MOCK_USER } from '../types';
 
@@ -9,6 +10,18 @@ interface UserProfileProps {
 }
 
 function UserProfile({ isCollapsed }: UserProfileProps) {
+  const { user } = useAuthStore();
+
+  // 스토어에 유저 정보가 없으면 Mock 데이터 사용 (개발 중 편의)
+  const displayUser = user
+    ? {
+        name: user.name,
+        email: user.email,
+        avatar: user.avatar || MOCK_USER.avatar,
+        workspace: MOCK_USER.workspace, // 워크스페이스 정보는 아직 스토어에 없음
+      }
+    : MOCK_USER;
+
   return (
     <div
       className={cn(
@@ -24,18 +37,18 @@ function UserProfile({ isCollapsed }: UserProfileProps) {
       >
         <div className="border-sidebar-border relative size-9 shrink-0 overflow-hidden rounded-full border shadow-sm">
           <img
-            src={MOCK_USER.avatar}
-            alt={MOCK_USER.name}
+            src={displayUser.avatar}
+            alt={displayUser.name}
             className="h-full w-full object-cover"
           />
         </div>
         {!isCollapsed && (
           <div className="flex flex-1 flex-col overflow-hidden">
             <p className="text-sidebar-foreground truncate text-sm font-bold">
-              {MOCK_USER.name}
+              {displayUser.name}
             </p>
             <p className="text-sidebar-foreground/60 truncate text-xs">
-              {MOCK_USER.email}
+              {displayUser.email}
             </p>
           </div>
         )}
@@ -49,10 +62,10 @@ function UserProfile({ isCollapsed }: UserProfileProps) {
               워크스페이스
             </span>
             <span className="bg-primary/10 text-primary rounded px-1.5 py-0.5 text-xs font-medium">
-              {MOCK_USER.workspace.role}
+              {displayUser.workspace.role}
             </span>
             <span className="text-sidebar-foreground/50 text-xs">
-              {MOCK_USER.workspace.permission}
+              {displayUser.workspace.permission}
             </span>
           </div>
         </div>
@@ -62,7 +75,7 @@ function UserProfile({ isCollapsed }: UserProfileProps) {
         <div className="flex flex-col gap-1">
           <div
             className="bg-primary/10 rounded p-1"
-            title={`${MOCK_USER.workspace.role} (${MOCK_USER.workspace.permission})`}
+            title={`${displayUser.workspace.role} (${displayUser.workspace.permission})`}
           >
             <Shield className="text-primary size-3.5 stroke-2" />
           </div>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,12 +1,11 @@
 /**
  * API 관련 상수 정의
  *
- * - 개발 환경: 항상 /api (Vite Proxy) 사용하여 CORS 우회
- * - 프로덕션: VITE_API_BASE_URL로 직접 서버에 요청
+ * 항상 VITE_API_BASE_URL 환경변수를 직접 사용
+ * (.env.local에서 설정)
  */
-export const API_BASE_URL = import.meta.env.DEV
-  ? '/api'
-  : import.meta.env.VITE_API_BASE_URL || 'https://dev-api.playprobie.shop';
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || 'https://dev-api.playprobie.shop';
 
 export const CLIENT_BASE_URL =
   import.meta.env.VITE_CLIENT_BASE_URL || 'http://localhost:5173';

--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -29,20 +29,54 @@ export type GameGenre = ConfigValue<typeof GameGenreConfig>;
 // API Request/Response Types (snake_case)
 // ----------------------------------------
 
-/** [API] POST /games Request */
-export interface ApiCreateGameRequest {
+/** [API] Game 엔티티 */
+export interface ApiGame {
+  game_uuid: string;
+  workspace_uuid: string;
   game_name: string;
+  game_genre: string[];
   game_context: string;
-  game_genre: GameGenre[];
+  created_at: string;
+  updated_at: string;
 }
 
-/** [API] 게임 엔티티 */
-export interface ApiGame {
-  game_id: number;
+/** [API] POST /workspaces/{workspaceUuid}/games Request */
+export interface ApiCreateGameRequest {
   game_name: string;
+  game_genre: string[];
   game_context: string;
-  game_genre: GameGenre[];
-  created_at: string;
+}
+
+/** [API] PUT /games/{gameUuid} Request */
+export interface ApiUpdateGameRequest {
+  game_name: string;
+  game_genre: string[];
+  game_context: string;
+}
+
+/** [API] Game Response wrapper */
+export interface ApiGameResponse {
+  result: ApiGame;
+}
+
+/** [API] Games List Response wrapper */
+export interface ApiGamesListResponse {
+  result: ApiGame[];
+}
+
+// ----------------------------------------
+// Client State Types (camelCase)
+// ----------------------------------------
+
+/** [Client] 게임 엔티티 */
+export interface Game {
+  gameUuid: string;
+  workspaceUuid: string;
+  gameName: string;
+  gameGenre: string[];
+  gameContext: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /** [API] POST /games Response */
@@ -50,24 +84,55 @@ export interface CreateGameResponse {
   result: ApiGame;
 }
 
-// ----------------------------------------
-// Client State Types (camelCase)
-// ----------------------------------------
-
 /** [Client] 게임 생성 요청 */
 export interface CreateGameRequest {
   gameName: string;
+  gameGenre: string[];
   gameContext: string;
-  gameGenre: GameGenre[];
 }
 
-/** [Client] 게임 엔티티 */
-export interface Game {
-  gameId: number;
+/** [Client] 게임 수정 요청 */
+export interface UpdateGameRequest {
   gameName: string;
+  gameGenre: string[];
   gameContext: string;
-  gameGenre: GameGenre[];
-  createdAt: string;
 }
 
-// NOTE: API <-> Client 변환기는 실제 사용 시점에 맞춰 추가합니다.
+// ----------------------------------------
+// Transformers
+// ----------------------------------------
+
+/** ApiGame → Game 변환 */
+export function toGame(api: ApiGame): Game {
+  return {
+    gameUuid: api.game_uuid,
+    workspaceUuid: api.workspace_uuid,
+    gameName: api.game_name,
+    gameGenre: api.game_genre,
+    gameContext: api.game_context,
+    createdAt: api.created_at,
+    updatedAt: api.updated_at,
+  };
+}
+
+/** CreateGameRequest → ApiCreateGameRequest 변환 */
+export function toApiCreateGameRequest(
+  client: CreateGameRequest
+): ApiCreateGameRequest {
+  return {
+    game_name: client.gameName,
+    game_genre: client.gameGenre,
+    game_context: client.gameContext,
+  };
+}
+
+/** UpdateGameRequest → ApiUpdateGameRequest 변환 */
+export function toApiUpdateGameRequest(
+  client: UpdateGameRequest
+): ApiUpdateGameRequest {
+  return {
+    game_name: client.gameName,
+    game_genre: client.gameGenre,
+    game_context: client.gameContext,
+  };
+}

--- a/src/features/survey-design/hooks/useFormSubmit.ts
+++ b/src/features/survey-design/hooks/useFormSubmit.ts
@@ -14,7 +14,7 @@ type SubmitStep = 'game' | 'survey' | 'questions';
 
 /** 트랜잭션 상태 (롤백용) */
 type TransactionState = {
-  gameId?: number;
+  gameUuid?: string;
   surveyId?: number;
 };
 
@@ -69,15 +69,15 @@ export function useFormSubmit(options?: UseFormSubmitOptions) {
       const transactionState: TransactionState = {};
 
       // 1. 게임 생성
-      let gameId: number;
+      let gameUuid: string;
       try {
         const gameResponse = await postGame({
           game_name: gameName || '',
           game_context: gameContext || '',
           game_genre: gameGenre || [],
         });
-        gameId = gameResponse.result.game_id;
-        transactionState.gameId = gameId;
+        gameUuid = gameResponse.result.game_uuid;
+        transactionState.gameUuid = gameUuid;
       } catch (error) {
         throw new SurveySubmitError(
           '게임 생성에 실패했습니다.',
@@ -100,7 +100,7 @@ export function useFormSubmit(options?: UseFormSubmitOptions) {
         };
 
         const surveyResponse = await postSurvey({
-          game_id: gameId,
+          game_uuid: gameUuid,
           survey_name: surveyName || '',
           started_at: formatToISO(startedAt || ''),
           ended_at: formatToISO(endedAt || ''),

--- a/src/features/survey-design/types.ts
+++ b/src/features/survey-design/types.ts
@@ -32,7 +32,7 @@ export type TestPurpose = ConfigValue<typeof TestPurposeConfig>;
 
 /** [API] POST /surveys Request */
 export interface ApiCreateSurveyRequest {
-  game_id: number;
+  game_uuid: string;
   survey_name: string;
   started_at: string;
   ended_at: string;
@@ -120,7 +120,7 @@ export interface CreateFixedQuestionsResponse {
 
 /** [Client] 설문 생성 요청 */
 export interface CreateSurveyRequest {
-  gameId: number;
+  gameUuid: string;
   surveyName: string;
   startedAt: string;
   endedAt: string;

--- a/src/lib/msw/handlers/games.ts
+++ b/src/lib/msw/handlers/games.ts
@@ -21,11 +21,13 @@ export const gamesHandlers = [
 
       const response: CreateGameResponse = {
         result: {
-          game_id: Math.floor(Math.random() * 10000) + 1,
+          game_uuid: crypto.randomUUID(),
+          workspace_uuid: crypto.randomUUID(),
           game_name: body.game_name,
-          game_context: body.game_context,
           game_genre: body.game_genre,
+          game_context: body.game_context,
           created_at: toKSTISOString(new Date()),
+          updated_at: toKSTISOString(new Date()),
         },
       };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,25 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
+/**
+ * 전역 fetch 오버라이드
+ * 모든 fetch 요청에 Authorization 헤더 자동 적용 (localStorage 토큰 사용)
+ */
+const originalFetch = window.fetch;
+window.fetch = (input, init) => {
+  const token = localStorage.getItem('accessToken');
+  const headers = new Headers(init?.headers);
+
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return originalFetch(input, {
+    ...init,
+    headers,
+  });
+};
+
 import { router } from '@/app/router';
 
 /**

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -51,9 +51,9 @@ export default function LoginPage() {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
     if (errors[name as keyof FormErrors]) {
-      setErrors(prev => ({ ...prev, [name]: undefined }));
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
     }
     if (apiError) {
       setApiError(null);
@@ -70,7 +70,6 @@ export default function LoginPage() {
     try {
       const response = await fetch(`${API_BASE_URL}/auth/login`, {
         method: 'POST',
-        credentials: 'include', // HttpOnly Cookie 수신
         headers: {
           'Content-Type': 'application/json',
         },
@@ -86,9 +85,14 @@ export default function LoginPage() {
       }
 
       const data = await response.json();
-      const { user } = data.result;
-      
-      // 서버에서 반환한 사용자 정보 저장 (JWT는 HttpOnly Cookie에 저장됨)
+      const { user, access_token: accessToken } = data.result;
+
+      // accessToken을 localStorage에 저장 (전역 fetch 인터셉터가 자동으로 헤더에 추가)
+      if (accessToken) {
+        localStorage.setItem('accessToken', accessToken);
+      }
+
+      // 사용자 정보 저장
       login({
         id: String(user.id),
         email: user.email,
@@ -98,7 +102,9 @@ export default function LoginPage() {
       navigate(from, { replace: true });
     } catch (error) {
       console.error('Login failed:', error);
-      setApiError(error instanceof Error ? error.message : '로그인 중 오류가 발생했습니다');
+      setApiError(
+        error instanceof Error ? error.message : '로그인 중 오류가 발생했습니다'
+      );
     } finally {
       setIsLoading(false);
     }
@@ -141,10 +147,16 @@ export default function LoginPage() {
         )}
 
         {/* Login Form */}
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4"
+        >
           {/* 이메일 */}
           <div className="space-y-2">
-            <label htmlFor="email" className="text-foreground text-sm font-medium">
+            <label
+              htmlFor="email"
+              className="text-foreground text-sm font-medium"
+            >
               이메일
             </label>
             <Input
@@ -164,7 +176,10 @@ export default function LoginPage() {
 
           {/* 비밀번호 */}
           <div className="space-y-2">
-            <label htmlFor="password" className="text-foreground text-sm font-medium">
+            <label
+              htmlFor="password"
+              className="text-foreground text-sm font-medium"
+            >
               비밀번호
             </label>
             <Input
@@ -201,7 +216,7 @@ export default function LoginPage() {
         {/* Google Login */}
         <Button
           disabled
-          className="w-full mb-4"
+          className="mb-4 w-full"
         >
           <svg
             className="h-5 w-5"
@@ -231,7 +246,7 @@ export default function LoginPage() {
         <Button
           variant="outline"
           onClick={handleRegister}
-          className="w-full mb-4"
+          className="mb-4 w-full"
         >
           회원가입
         </Button>

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -72,10 +72,10 @@ export default function RegisterPage() {
   const formatPhoneNumber = (value: string): string => {
     // 숫자만 추출
     const numbers = value.replace(/\D/g, '');
-    
+
     // 최대 11자리까지만 허용
     const limited = numbers.slice(0, 11);
-    
+
     // 포맷 적용
     if (limited.length <= 3) {
       return limited;
@@ -88,14 +88,14 @@ export default function RegisterPage() {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    
+
     // 전화번호 필드는 포맷팅 적용
     const formattedValue = name === 'phone' ? formatPhoneNumber(value) : value;
-    
-    setFormData(prev => ({ ...prev, [name]: formattedValue }));
+
+    setFormData((prev) => ({ ...prev, [name]: formattedValue }));
     // 입력 시 해당 필드 에러 및 API 에러 제거
     if (errors[name as keyof FormErrors]) {
-      setErrors(prev => ({ ...prev, [name]: undefined }));
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
     }
     if (apiError) {
       setApiError(null);
@@ -125,13 +125,13 @@ export default function RegisterPage() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        
+
         // 이메일 중복 에러 (code: U002)
         if (errorData.code === 'U002') {
-          setErrors(prev => ({ ...prev, email: errorData.message }));
+          setErrors((prev) => ({ ...prev, email: errorData.message }));
           return;
         }
-        
+
         throw new Error(errorData.message || '회원가입에 실패했습니다');
       }
 
@@ -139,7 +139,11 @@ export default function RegisterPage() {
       navigate('/login', { state: { registered: true } });
     } catch (error) {
       console.error('Registration failed:', error);
-      setApiError(error instanceof Error ? error.message : '회원가입 중 오류가 발생했습니다');
+      setApiError(
+        error instanceof Error
+          ? error.message
+          : '회원가입 중 오류가 발생했습니다'
+      );
     } finally {
       setIsLoading(false);
     }
@@ -173,10 +177,16 @@ export default function RegisterPage() {
         )}
 
         {/* Form */}
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4"
+        >
           {/* 이메일 */}
           <div className="space-y-2">
-            <label htmlFor="email" className="text-foreground text-sm font-medium">
+            <label
+              htmlFor="email"
+              className="text-foreground text-sm font-medium"
+            >
               이메일 <span className="text-destructive">*</span>
             </label>
             <Input
@@ -196,7 +206,10 @@ export default function RegisterPage() {
 
           {/* 비밀번호 */}
           <div className="space-y-2">
-            <label htmlFor="password" className="text-foreground text-sm font-medium">
+            <label
+              htmlFor="password"
+              className="text-foreground text-sm font-medium"
+            >
               비밀번호 <span className="text-destructive">*</span>
             </label>
             <Input
@@ -216,7 +229,10 @@ export default function RegisterPage() {
 
           {/* 비밀번호 확인 */}
           <div className="space-y-2">
-            <label htmlFor="passwordConfirm" className="text-foreground text-sm font-medium">
+            <label
+              htmlFor="passwordConfirm"
+              className="text-foreground text-sm font-medium"
+            >
               비밀번호 확인 <span className="text-destructive">*</span>
             </label>
             <Input
@@ -230,13 +246,18 @@ export default function RegisterPage() {
               autoComplete="new-password"
             />
             {errors.passwordConfirm && (
-              <p className="text-destructive text-sm">{errors.passwordConfirm}</p>
+              <p className="text-destructive text-sm">
+                {errors.passwordConfirm}
+              </p>
             )}
           </div>
 
           {/* 이름 */}
           <div className="space-y-2">
-            <label htmlFor="name" className="text-foreground text-sm font-medium">
+            <label
+              htmlFor="name"
+              className="text-foreground text-sm font-medium"
+            >
               이름 <span className="text-destructive">*</span>
             </label>
             <Input
@@ -256,8 +277,12 @@ export default function RegisterPage() {
 
           {/* 전화번호 (선택) */}
           <div className="space-y-2">
-            <label htmlFor="phone" className="text-foreground text-sm font-medium">
-              전화번호 <span className="text-muted-foreground text-xs">(선택)</span>
+            <label
+              htmlFor="phone"
+              className="text-foreground text-sm font-medium"
+            >
+              전화번호{' '}
+              <span className="text-muted-foreground text-xs">(선택)</span>
             </label>
             <Input
               id="phone"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,20 +15,18 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      proxy: {
-        '/api': {
-          target: env.VITE_API_BASE_URL || 'http://localhost:8080',
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api/, ''),
-          secure: false,
-          configure: (proxy, _options) => {
-            proxy.on('proxyReq', (proxyReq, _req, _res) => {
-              // 서버가 Origin 헤더가 있으면 엄격하게 검사하므로 아예 제거합니다.
-              proxyReq.removeHeader('Origin');
-            });
-          },
-        },
-      },
+      // MSW 활성화 시 proxy를 비활성화하여 Service Worker가 요청을 가로채도록 함
+      proxy:
+        env.VITE_MSW_ENABLED === 'true'
+          ? undefined
+          : {
+              '/api': {
+                target: env.VITE_API_BASE_URL || 'http://localhost:8080',
+                changeOrigin: true,
+                rewrite: (path) => path.replace(/^\/api/, ''),
+                secure: false,
+              },
+            },
     },
   };
 });


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #

## ✨ 작업 내용 (Summary)
- 인증 방식을 Cookie 기반에서 localStorage + Bearer Token 헤더 방식으로 변경
- 전역 fetch 인터셉터를 통해 모든 API 요청에 토큰 자동 주입
- 사이드바 UserProfile에 전역 Auth 스토어 연결 (실제 유저 정보 표시)
- Game/Survey 관련 API 및 MSW 핸들러의 식별자를 game_id에서 game_uuid로 변경

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [ ] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [ ] 빌드 및 테스트가 통과하였는가?

