### PR TITLE
refactor: 설문 분석 API 호출 시 UUID 사용하도록 변경

### DIFF
--- a/src/features/survey-analytics/api/get-question-analysis.ts
+++ b/src/features/survey-analytics/api/get-question-analysis.ts
@@ -7,7 +7,7 @@ import type { QuestionResponseAnalysisWrapper } from '../types';
  * 개발 환경(MSW)에서는 일반 JSON 응답으로 처리
  */
 export async function getQuestionAnalysis(
-  surveyId: number,
+  surveyUuid: string,
   onMessage: (data: QuestionResponseAnalysisWrapper) => void,
   onError?: (error: Error) => void,
   onComplete?: () => void
@@ -15,7 +15,7 @@ export async function getQuestionAnalysis(
   // MSW 환경에서는 일반 fetch 사용
   if (import.meta.env.DEV && import.meta.env.VITE_MSW_ENABLED === 'true') {
     try {
-      const response = await fetch(`${API_BASE_URL}/analytics/${surveyId}`);
+      const response = await fetch(`${API_BASE_URL}/analytics/${surveyUuid}`);
       
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -43,8 +43,8 @@ export async function getQuestionAnalysis(
   // 프로덕션: 실제 SSE 사용
   // 개발 환경에서는 Vite proxy를 통해야 하므로 상대 경로 사용
   const sseUrl = import.meta.env.DEV
-    ? `/api/analytics/${surveyId}`
-    : `${API_BASE_URL}/analytics/${surveyId}`;
+    ? `/api/analytics/${surveyUuid}`
+    : `${API_BASE_URL}/analytics/${surveyUuid}`;
 
   const eventSource = new EventSource(sseUrl);
 

--- a/src/pages/survey/SurveyAnalyticsPage.tsx
+++ b/src/pages/survey/SurveyAnalyticsPage.tsx
@@ -17,20 +17,20 @@ import {
  * URL: /survey/analytics/:gameUuid
  */
 function SurveyAnalyticsPage() {
-  const { gameUuid } = useParams<{ gameUuid: string }>();
+  const { gameUuid, surveyUuid } = useParams<{
+    gameUuid: string;
+    surveyUuid: string;
+  }>();
   const [activeTab, setActiveTab] = useState<Tab>('overview');
 
   const { summary, list, isLoading, isError } = useSurveyResults({
     gameUuid: gameUuid || '',
   });
 
-  // MVP: surveyId 임시 고정 (나중에 list[0]?.surveyId 또는 URL param으로 변경)
-  const surveyId = list[0]?.surveyId || 0;
-
   // 페이지 레벨에서 SSE 분석 요청 (한 번만 실행)
   const questionAnalysis = useQuestionAnalysis({
-    surveyId: surveyId || null,
-    enabled: Boolean(surveyId),
+    surveyUuid: surveyUuid || null,
+    enabled: Boolean(surveyUuid),
   });
 
   return (
@@ -59,7 +59,7 @@ function SurveyAnalyticsPage() {
           </div>
 
           {/* 설문 개요 탭 */}
-          {activeTab === 'overview' && Boolean(surveyId) && (
+          {activeTab === 'overview' && Boolean(surveyUuid) && (
             <SurveyOverview
               summary={summary}
               questionAnalysis={questionAnalysis}
@@ -67,13 +67,13 @@ function SurveyAnalyticsPage() {
           )}
 
           {/* 질문별 분석 탭 */}
-          {activeTab === 'questions' && Boolean(surveyId) && (
+          {activeTab === 'questions' && Boolean(surveyUuid) && (
             <QuestionAnalysisView
               questionAnalysis={questionAnalysis}
             />
           )}
 
-          {activeTab === 'questions' && surveyId === 0 && (
+          {activeTab === 'questions' && !surveyUuid && (
             <div className="py-12 text-center text-muted-foreground">
               분석할 설문 데이터가 없습니다.
             </div>


### PR DESCRIPTION
- getQuestionAnalysis 함수의 파라미터를 surveyId(number)에서 surveyUuid(string)으로 변경
- API 요청 URL에 surveyId 대신 surveyUuid를 사용하도록 수정

## 📌 관련 이슈
- Closes #37 

## ✨ 작업 내용 (Summary)
- [x] getQuestionAnalysis 함수의 파라미터를 surveyId(number)에서 surveyUuid(string)으로 변경
- [x] API 요청 URL에 surveyId 대신 surveyUuid를 사용하도록 수정


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

