### PR TITLE
refactor: Analytics 조회 방식을 SSE에서 REST API로 변경

### DIFF
--- a/src/features/game-streaming/api/get-builds.ts
+++ b/src/features/game-streaming/api/get-builds.ts
@@ -3,6 +3,7 @@
  * GET /games/{gameUuid}/builds
  */
 import { API_BASE_URL } from '@/constants/api';
+
 import type { ApiBuild, Build } from '../types';
 import { toBuild } from '../types';
 import { apiFetch } from '../utils';

--- a/src/features/survey-analytics/api/get-question-analysis.ts
+++ b/src/features/survey-analytics/api/get-question-analysis.ts
@@ -2,9 +2,17 @@ import { API_BASE_URL } from '@/constants/api';
 
 import type { QuestionResponseAnalysisWrapper } from '../types';
 
+/** Analytics 응답 타입 */
+interface AnalyticsResponse {
+  analyses: QuestionResponseAnalysisWrapper[];
+  status: 'COMPLETED' | 'NO_DATA' | 'INSUFFICIENT_DATA';
+  total_questions: number;
+  completed_questions: number;
+}
+
 /**
- * GET /api/analytics/{surveyId} - 설문 질문별 AI 분석 결과 (SSE 스트리밍)
- * 개발 환경(MSW)에서는 일반 JSON 응답으로 처리
+ * GET /api/analytics/{surveyUuid} - 설문 질문별 AI 분석 결과
+ * SSE에서 REST API로 전환됨
  */
 export async function getQuestionAnalysis(
   surveyUuid: string,
@@ -12,72 +20,33 @@ export async function getQuestionAnalysis(
   onError?: (error: Error) => void,
   onComplete?: () => void
 ): Promise<() => void> {
-  // MSW 환경에서는 일반 fetch 사용
-  if (import.meta.env.DEV && import.meta.env.VITE_MSW_ENABLED === 'true') {
-    try {
-      const response = await fetch(`${API_BASE_URL}/analytics/${surveyUuid}`);
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      
-      const data: QuestionResponseAnalysisWrapper[] = await response.json();
-      
-      // 배열로 받은 데이터를 순차적으로 처리 (SSE 시뮬레이션)
-      for (const item of data) {
-        onMessage(item);
-      }
-      
-      onComplete?.();
-      
-      // cleanup 함수 (MSW에서는 아무 것도 안 함)
-      return () => {};
-    } catch (error) {
-      onError?.(
-        error instanceof Error ? error : new Error('Failed to fetch analytics')
-      );
-      return () => {};
+  try {
+    // REST API 호출 (Authorization 헤더는 글로벌 인터셉터가 자동 추가)
+    const url = import.meta.env.DEV
+      ? `/api/analytics/${surveyUuid}`
+      : `${API_BASE_URL}/analytics/${surveyUuid}`;
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
     }
-  }
 
-  // 프로덕션: 실제 SSE 사용
-  // 개발 환경에서는 Vite proxy를 통해야 하므로 상대 경로 사용
-  const sseUrl = import.meta.env.DEV
-    ? `/api/analytics/${surveyUuid}`
-    : `${API_BASE_URL}/analytics/${surveyUuid}`;
+    const data: AnalyticsResponse = await response.json();
 
-  const eventSource = new EventSource(sseUrl);
-
-  eventSource.onmessage = (event) => {
-    try {
-      const data: QuestionResponseAnalysisWrapper = JSON.parse(event.data);
-      onMessage(data);
-    } catch (error) {
-      console.error('Failed to parse SSE data:', error);
-      onError?.(
-        error instanceof Error ? error : new Error('Failed to parse SSE data')
-      );
+    // 분석 결과 순차 콜백 호출 (기존 인터페이스 호환)
+    for (const item of data.analyses) {
+      onMessage(item);
     }
-  };
 
-  // 서버에서 보내는 'complete' 이벤트 리스닝
-  eventSource.addEventListener('complete', () => {
-    eventSource.close();
+    // 모든 상태에서 완료 처리 (IN_PROGRESS는 서버에서 반환하지 않음)
     onComplete?.();
-  });
 
-  eventSource.onerror = (event) => {
-    // readyState가 CONNECTING(0)이면 재연결 시도 중이므로 무시
-    if (eventSource.readyState === EventSource.CONNECTING) {
-      return;
-    }
-    console.error('SSE connection error:', event);
-    eventSource.close();
-    onError?.(new Error('SSE connection failed'));
-  };
-
-  // cleanup 함수 반환
-  return () => {
-    eventSource.close();
-  };
+    return () => {}; // cleanup (REST는 cleanup 불필요)
+  } catch (error) {
+    onError?.(
+      error instanceof Error ? error : new Error('Failed to fetch analytics')
+    );
+    return () => {};
+  }
 }

--- a/src/features/survey-analytics/hooks/useSurveyResults.ts
+++ b/src/features/survey-analytics/hooks/useSurveyResults.ts
@@ -31,7 +31,6 @@ function useSurveyResults({ gameUuid }: UseSurveyResultsOptions) {
         sessionUuid: item.session_uuid,
         surveyName: item.survey_name,
         surveyUuid: item.survey_uuid,
-        surveyId: item.survey_id,
         testerId: item.tester_id,
         status: item.status,
         endedAt: item.ended_at,

--- a/src/features/survey-analytics/types.ts
+++ b/src/features/survey-analytics/types.ts
@@ -25,7 +25,6 @@ export interface ApiSurveySession {
   session_uuid: string;
   survey_name: string;
   survey_uuid: string;
-  survey_id: number;
   tester_id: string;
   status: SurveySessionStatus;
   ended_at: string;
@@ -174,7 +173,6 @@ export interface SurveySession {
   sessionUuid: string;
   surveyName: string;
   surveyUuid: string;
-  surveyId: number;
   testerId: string;
   status: SurveySessionStatus;
   endedAt: string;

--- a/src/lib/msw/handlers/survey-analytics.ts
+++ b/src/lib/msw/handlers/survey-analytics.ts
@@ -110,7 +110,6 @@ export const surveyAnalyticsHandlers = [
             session_uuid: sessionUuid,
             survey_name: 'Escape From Duckov 플레이테스트',
             survey_uuid: surveyUuid,
-            survey_id: 100,
             tester_id: 'tester-uuid-123',
             status: 'COMPLETED',
             ended_at: '2025-12-27T16:40:00+09:00',
@@ -475,10 +474,15 @@ export const surveyAnalyticsHandlers = [
         }),
       };
 
-      // Mock: 개발 환경에서는 배열로 반환 (SSE 대신)
+      // REST API 응답 구조 (AnalyticsResponse)
       const questions = [question1, question2, question3];
 
-      return HttpResponse.json(questions);
+      return HttpResponse.json({
+        analyses: questions,
+        status: 'COMPLETED',
+        total_questions: 3,
+        completed_questions: 3,
+      });
     }
   ),
 ];


### PR DESCRIPTION

## 📌 관련 이슈
- Closes #60 

## ✨ 작업 내용 (Summary)
- [x] get-question-analysis.ts: EventSource를 fetch API로 대체
- [x] survey-analytics.ts: MSW Mock 응답 구조를 REST API 명세에 맞춰 수정
- [x] SSE 관련 타입 및 불필요한 에러 핸들링 로직 제거

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] msw 서버에서 동작 (server 추가 수정 중)

