### PR TITLE
fix: 설문 진행 시 게임 세션 UUID 연동 (서버 통합)

### DIFF
--- a/src/features/game-streaming-session/components/StreamCompletionDialog.tsx
+++ b/src/features/game-streaming-session/components/StreamCompletionDialog.tsx
@@ -11,18 +11,20 @@ import {
 interface StreamCompletionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  sessionUuid?: string;
+  sessionUuid: string;
+  surveyUuid: string;
 }
 
 export function StreamCompletionDialog({
   open,
   onOpenChange,
   sessionUuid,
+  surveyUuid,
 }: StreamCompletionDialogProps) {
   const handleStartSurvey = () => {
     if (!sessionUuid) return;
     const baseUrl = import.meta.env.VITE_CLIENT_BASE_URL || '';
-    window.location.href = `${baseUrl}/surveys/session/${sessionUuid}`;
+    window.location.href = `${baseUrl}/surveys/session/${surveyUuid}?sessionUuid=${sessionUuid}`;
   };
 
   return (

--- a/src/features/survey-session/api/create-chat-session.ts
+++ b/src/features/survey-session/api/create-chat-session.ts
@@ -11,6 +11,7 @@ import type {
 export async function createChatSession({
   surveyUuid,
   testerProfile,
+  sessionUuid,
 }: CreateChatSessionParams): Promise<CreateChatSessionResponse> {
   const response = await fetch(`${API_BASE_URL}/interview/${surveyUuid}`, {
     method: 'POST',
@@ -21,6 +22,7 @@ export async function createChatSession({
       age_group: testerProfile?.ageGroup,
       gender: testerProfile?.gender,
       prefer_genre: testerProfile?.preferGenre,
+      session_uuid: sessionUuid,
     }), // 프로필 정보가 있으면 전송, 없으면 빈 객체 (또는 null)
   });
 

--- a/src/features/survey-session/types.ts
+++ b/src/features/survey-session/types.ts
@@ -20,7 +20,13 @@
 export type SurveySessionStatus = 'IN_PROGRESS' | 'COMPLETED' | 'DROPPED';
 
 /** 인터뷰 로그 질문 타입 */
-export type InterviewLogQType = 'FIXED' | 'TAIL' | 'OPENING' | 'CLOSING' | 'GREETING' | 'REACTION';
+export type InterviewLogQType =
+  | 'FIXED'
+  | 'TAIL'
+  | 'OPENING'
+  | 'CLOSING'
+  | 'GREETING'
+  | 'REACTION';
 
 /** 테스터 프로필 데이터 */
 export interface TesterProfile {
@@ -205,6 +211,7 @@ export interface ChatMessageData {
 /** 새 대화 세션 생성 요청 파라미터 */
 export interface CreateChatSessionParams {
   surveyUuid: string;
+  sessionUuid?: string;
   testerProfile?: TesterProfile;
 }
 

--- a/src/pages/play/StreamingPlayPage.tsx
+++ b/src/pages/play/StreamingPlayPage.tsx
@@ -35,8 +35,11 @@ export default function StreamingPlayPage() {
     []
   );
 
-  // 종료 완료 모달 상태
-  const [showCompletionModal, setShowCompletionModal] = useState(false);
+  // 종료 완료 모달 상태 (데이터 포함)
+  const [completionInfo, setCompletionInfo] = useState<{
+    sessionUuid: string;
+    surveyUuid: string;
+  } | null>(null);
 
   // 남은 시간 타이머
   const [remainingTime, setRemainingTime] = useState(
@@ -164,8 +167,17 @@ export default function StreamingPlayPage() {
       },
       {
         onSuccess: () => {
+          if (!sessionUuid || !surveyUuid) {
+            toast({
+              variant: 'destructive',
+              title: '오류 발생',
+              description: '세션 정보가 없어 설문으로 이동할 수 없습니다.',
+            });
+            return;
+          }
+
+          setCompletionInfo({ sessionUuid, surveyUuid });
           disconnect();
-          setShowCompletionModal(true);
         },
         onError: (error) => {
           toast({
@@ -272,9 +284,10 @@ export default function StreamingPlayPage() {
       />
 
       <StreamCompletionDialog
-        open={showCompletionModal}
-        onOpenChange={setShowCompletionModal}
-        sessionUuid={sessionUuid || undefined}
+        open={!!completionInfo}
+        onOpenChange={(open) => !open && setCompletionInfo(null)}
+        sessionUuid={completionInfo?.sessionUuid ?? ''}
+        surveyUuid={completionInfo?.surveyUuid ?? ''}
       />
     </div>
   );

--- a/src/pages/survey/SurveySessionStartPage.tsx
+++ b/src/pages/survey/SurveySessionStartPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import {
   Button,
@@ -22,6 +22,8 @@ import type { TesterProfile } from '@/features/survey-session/types';
 
 function SurveySessionStartPage() {
   const { surveyUuid } = useParams<{ surveyUuid: string }>();
+  const [searchParams] = useSearchParams();
+  const sessionUuid = searchParams.get('sessionUuid');
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -55,6 +57,7 @@ function SurveySessionStartPage() {
       const response = await createChatSession({
         surveyUuid: surveyUuid,
         testerProfile: profile,
+        sessionUuid: sessionUuid || undefined,
       });
 
       const { session, sse_url: sseUrl } = response.result;
@@ -78,7 +81,10 @@ function SurveySessionStartPage() {
   if (isLoading) {
     return (
       <div className="bg-background flex min-h-screen flex-col items-center justify-center px-4">
-        <Spinner size="lg" className="text-primary mb-4" />
+        <Spinner
+          size="lg"
+          className="text-primary mb-4"
+        />
         <p className="text-muted-foreground">인터뷰를 준비하고 있습니다...</p>
       </div>
     );
@@ -88,7 +94,9 @@ function SurveySessionStartPage() {
     <div className="bg-background flex min-h-screen flex-col items-center justify-center px-4 py-8">
       <div className="w-full max-w-md space-y-8">
         <div className="text-center">
-          <h1 className="text-2xl font-bold tracking-tight">테스터 정보 입력</h1>
+          <h1 className="text-2xl font-bold tracking-tight">
+            테스터 정보 입력
+          </h1>
           <p className="text-muted-foreground mt-2">
             원활한 인터뷰 진행을 위해 간단한 정보를 입력해주세요.
           </p>
@@ -98,7 +106,10 @@ function SurveySessionStartPage() {
           {/* 성별 선택 */}
           <div className="space-y-2">
             <Label>성별</Label>
-            <Select onValueChange={setGender} value={gender}>
+            <Select
+              onValueChange={setGender}
+              value={gender}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="성별을 선택하세요" />
               </SelectTrigger>
@@ -112,7 +123,10 @@ function SurveySessionStartPage() {
           {/* 연령대 선택 */}
           <div className="space-y-2">
             <Label>연령대</Label>
-            <Select onValueChange={setAgeGroup} value={ageGroup}>
+            <Select
+              onValueChange={setAgeGroup}
+              value={ageGroup}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="연령대를 선택하세요" />
               </SelectTrigger>
@@ -140,7 +154,11 @@ function SurveySessionStartPage() {
             <p className="text-destructive text-sm font-medium">{error}</p>
           )}
 
-          <Button className="w-full" size="lg" onClick={handleStart}>
+          <Button
+            className="w-full"
+            size="lg"
+            onClick={handleStart}
+          >
             인터뷰 시작하기
           </Button>
         </div>


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #64 

## ✨ 작업 내용 (Summary)
- StreamCompletionDialog 필수 props 추가 및 쿼리 파라미터 전달 로직 구현
- CreateChatSessionParams 및 API 요청 바디에 session_uuid 필드 반영

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

