### PR TITLE
feat: 유저 세그먼트 분석을 위한 타입 정의 및 유틸리티 추가

### DIFF
--- a/src/features/survey-analytics/types.ts
+++ b/src/features/survey-analytics/types.ts
@@ -152,6 +152,13 @@ export interface OutlierInfo {
   sample_answers?: string[]; // 서버에서 변환된 실제 답변 텍스트 (최대 5개)
 }
 
+/** 테스터 프로필 정보 (답변별 매핑) */
+export interface AnswerProfile {
+  age_group: string;
+  gender: string;
+  prefer_genre: string; // "RPG, FPS" 형태
+}
+
 /** 질문별 AI 분석 결과 */
 export interface QuestionAnalysisResult {
   question_id: number;
@@ -160,6 +167,7 @@ export interface QuestionAnalysisResult {
   sentiment: SentimentStats;
   outliers: OutlierInfo | null;
   meta_summary: string | null;
+  answer_profiles?: Record<string, AnswerProfile>;
 }
 
 /** SSE로 받는 질문 분석 래퍼 (API 응답 - snake_case) */

--- a/src/features/survey-analytics/utils/parsePreferGenre.ts
+++ b/src/features/survey-analytics/utils/parsePreferGenre.ts
@@ -1,0 +1,11 @@
+/**
+ * 선호 장르 문자열을 파싱하여 배열로 반환합니다.
+ * @param preferGenreStr "RPG, FPS" 형태의 문자열
+ * @returns ["RPG", "FPS"] 형태의 배열
+ */
+export function parsePreferGenre(preferGenreStr: string | undefined | null): string[] {
+  if (!preferGenreStr) {
+    return [];
+  }
+  return preferGenreStr.split(',').map((genre) => genre.trim()).filter((g) => g.length > 0);
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #93 

## ✨ 작업 내용 (Summary)
- [x] 테스터 정보 매핑을 위한 AnswerProfile 인터페이스 정의
- [x] QuestoinAnalysisResult 타입에 answer_profiles 필드 추가
- [x] 선호 장르 문자열 파싱 유틸리티 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?
- [x] lint
