### PR TITLE
feat: 설문 개요 페이지에 테스터 통계 카드 추가

### DIFF
--- a/src/features/survey-analytics/components/SurveyOverview.tsx
+++ b/src/features/survey-analytics/components/SurveyOverview.tsx
@@ -10,6 +10,7 @@ import {
   getSentimentColorClass,
   getSentimentLabel,
 } from '../utils';
+import { ClusterDemographics } from './ClusterDemographics';
 import { GEQRadarChart } from './GEQRadarChart';
 
 type QuestionAnalysisState = {
@@ -44,7 +45,16 @@ function SurveyOverview({ summary, questionAnalysis }: SurveyOverviewProps) {
   const { data, questionIds, isLoading, isError } = questionAnalysis;
 
   const averageGEQ = calculateAverageGEQ(data);
+
+
+
   const sentimentStats = calculateAverageSentiment(data);
+
+  const firstAnalysis = Object.values(data)[0];
+  const demographics = {
+    answerIds: firstAnalysis?.answer_profiles ? Object.keys(firstAnalysis.answer_profiles) : [],
+    profiles: firstAnalysis?.answer_profiles || {},
+  };
 
   return (
     <div className="space-y-6">
@@ -104,7 +114,7 @@ function SurveyOverview({ summary, questionAnalysis }: SurveyOverviewProps) {
 
       {/* 분석 결과 */}
       {!isLoading && !isError && questionIds.length > 0 && (
-        <div className="grid gap-6 lg:grid-cols-2">
+        <div className="grid gap-6 lg:grid-cols-3">
           {/* 전체 감정 분석 */}
           <Card>
             <CardHeader>
@@ -173,6 +183,15 @@ function SurveyOverview({ summary, questionAnalysis }: SurveyOverviewProps) {
 
             </CardContent>
           </Card>
+
+
+          {/* 테스터 분포 (Demographics) */}
+          <div>
+             <ClusterDemographics 
+               answerIds={demographics.answerIds}
+               profiles={demographics.profiles}
+             />
+          </div>
         </div>
       )}
 

--- a/src/features/survey-analytics/types.ts
+++ b/src/features/survey-analytics/types.ts
@@ -159,15 +159,23 @@ export interface AnswerProfile {
   prefer_genre: string; // "RPG, FPS" 형태
 }
 
+/** 참여자 통계 정보 */
+export interface ParticipantStats {
+  age_groups: Record<string, number>;
+  genders: Record<string, number>;
+  genres: Record<string, number>;
+}
+
 /** 질문별 AI 분석 결과 */
 export interface QuestionAnalysisResult {
   question_id: number;
   total_answers: number;
-  clusters: ClusterInfo[];
+  clusters: ClusterInfo[] | null;
   sentiment: SentimentStats;
   outliers: OutlierInfo | null;
   meta_summary: string | null;
   answer_profiles?: Record<string, AnswerProfile>;
+  participant_stats?: ParticipantStats;
 }
 
 /** SSE로 받는 질문 분석 래퍼 (API 응답 - snake_case) */

--- a/src/features/survey-analytics/utils/aggregateAnalysis.ts
+++ b/src/features/survey-analytics/utils/aggregateAnalysis.ts
@@ -34,18 +34,20 @@ function calculateAverageGEQ(
 
   questionIds.forEach((questionId) => {
     const analysis = analysisMap[questionId];
-    analysis.clusters.forEach((cluster) => {
-      const weight = cluster.count;
-      totalWeight += weight;
+    if (analysis.clusters) {
+      analysis.clusters.forEach((cluster) => {
+        const weight = cluster.count;
+        totalWeight += weight;
 
-      sums.competence += cluster.geq_scores.competence * weight;
-      sums.immersion += cluster.geq_scores.immersion * weight;
-      sums.flow += cluster.geq_scores.flow * weight;
-      sums.tension += cluster.geq_scores.tension * weight;
-      sums.challenge += cluster.geq_scores.challenge * weight;
-      sums.positive_affect += cluster.geq_scores.positive_affect * weight;
-      sums.negative_affect += cluster.geq_scores.negative_affect * weight;
-    });
+        sums.competence += cluster.geq_scores.competence * weight;
+        sums.immersion += cluster.geq_scores.immersion * weight;
+        sums.flow += cluster.geq_scores.flow * weight;
+        sums.tension += cluster.geq_scores.tension * weight;
+        sums.challenge += cluster.geq_scores.challenge * weight;
+        sums.positive_affect += cluster.geq_scores.positive_affect * weight;
+        sums.negative_affect += cluster.geq_scores.negative_affect * weight;
+      });
+    }
   });
 
   if (totalWeight === 0) {


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #91

## ✨ 작업 내용 (Summary)
- [x] ClusterDemoGraphics를 재활용해 설문 단위 테스터 통계 카드 추가 

<img width="1381" height="703" alt="dashboard1" src="https://github.com/user-attachments/assets/1b3a9ee4-74ff-44d6-8f5d-af18964d016c" />

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?
- [x] lint
