### PR TITLE
fix: 설문 대시보드 대표 답변 UI 개선

### DIFF
--- a/src/features/survey-analytics/components/AnswerList.tsx
+++ b/src/features/survey-analytics/components/AnswerList.tsx
@@ -1,5 +1,11 @@
 import { MessageSquareText } from 'lucide-react';
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/Accordion';
 import { Badge } from '@/components/ui/Badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 
@@ -13,6 +19,12 @@ type AnswerListItem = {
 type AnswerListProps = {
   readonly answers: AnswerListItem[];
   readonly title?: string;
+};
+
+type QaPair = {
+  question: string;
+  answer: string;
+  type: 'FIXED' | 'TAIL';
 };
 
 /**
@@ -30,6 +42,34 @@ function AnswerList({ answers, title = '필터링된 원문 리스트' }: Answer
     if (sentiment === 'positive') return '긍정';
     if (sentiment === 'negative') return '부정';
     return '중립';
+  };
+
+  const parseQAPairs = (text: string): QaPair[] => {
+    const pairs: QaPair[] = [];
+    const regex = /Q:\s*([\s\S]*?)\s*A:\s*([\s\S]*?)(?=\s*Q:|$)/g;
+    
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      // 답변에서 [꼬리질문 N] 형식의 태그 제거 및 공백 정리
+      const rawAnswer = match[2];
+      const cleanAnswer = rawAnswer.replace(/\[꼬리질문\s*\d+\]/g, '').trim();
+
+      pairs.push({
+        question: match[1].trim(),
+        answer: cleanAnswer,
+        type: pairs.length === 0 ? 'FIXED' : 'TAIL',
+      });
+    }
+
+    if (pairs.length === 0) {
+      pairs.push({
+        question: '질문',
+        answer: text,
+        type: 'FIXED',
+      });
+    }
+
+    return pairs;
   };
 
   if (!answers || answers.length === 0) {
@@ -55,41 +95,110 @@ function AnswerList({ answers, title = '필터링된 원문 리스트' }: Answer
         <span className="text-xs text-muted-foreground">총 {answers.length}개</span>
       </CardHeader>
       
-      <CardContent className="space-y-3">
-        {answers.map((answer, index) => (
-          <div 
-            key={answer.id || index}
-            className="rounded-lg border bg-muted/30 p-4 transition-all hover:bg-muted/50"
-          >
-            <div className="mb-2 flex items-start justify-between gap-3">
-              <p className="flex-1 text-sm leading-relaxed text-foreground">
-                {answer.text}
-              </p>
-              {answer.sentiment && (
-                <Badge 
-                  variant="outline" 
-                  className={`shrink-0 ${getSentimentStyle(answer.sentiment)}`}
-                >
-                  {getSentimentLabel(answer.sentiment)}
-                </Badge>
+      <CardContent className="space-y-4">
+        {answers.map((answer, index) => {
+          const qaPairs = parseQAPairs(answer.text);
+          const firstPair = qaPairs[0];
+          const tailPairs = qaPairs.slice(1);
+          const hasTail = tailPairs.length > 0;
+          const itemId = `answer-${answer.id || index}`;
+
+          const FixedContent = (
+            <div className={`relative w-full rounded-lg border p-4 text-left transition-colors ${hasTail ? 'group-hover:bg-muted/50' : 'bg-muted/10'}`}>
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className={`px-2 py-0.5 text-xs font-semibold rounded ${
+                    firstPair.type === 'FIXED' 
+                      ? 'bg-primary/10 text-primary' 
+                      : 'bg-accent/10 text-accent-foreground'
+                  }`}>
+                    {firstPair.type === 'FIXED' ? '고정 질문' : '꼬리 질문'}
+                  </span>
+                  {hasTail && (
+                    <span className="text-xs text-muted-foreground flex items-center gap-0.5">
+                      <MessageSquareText className="h-3 w-3" />
+                      꼬리질문 {tailPairs.length}개
+                    </span>
+                  )}
+                </div>
+                {answer.sentiment && (
+                  <Badge 
+                    variant="outline"
+                    className={`shrink-0 ${getSentimentStyle(answer.sentiment)}`}
+                  >
+                    {getSentimentLabel(answer.sentiment)}
+                  </Badge>
+                )}
+              </div>
+              
+              <div className="space-y-1">
+                <p className="text-xs font-medium text-muted-foreground">
+                  {firstPair.question}
+                </p>
+                <p className="text-sm leading-relaxed text-foreground font-medium">
+                  {firstPair.answer}
+                </p>
+              </div>
+
+              {answer.tags && answer.tags.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-1">
+                  {answer.tags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="text-xs">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
               )}
             </div>
-            
-            {answer.tags && answer.tags.length > 0 && (
-              <div className="flex flex-wrap gap-1">
-                {answer.tags.map((tag) => (
-                  <Badge 
-                    key={tag}
-                    variant="secondary"
-                    className="text-xs"
-                  >
-                    {tag}
-                  </Badge>
-                ))}
+          );
+
+          if (!hasTail) {
+            return (
+              <div key={itemId}>
+                {FixedContent}
               </div>
-            )}
-          </div>
-        ))}
+            );
+          }
+
+          return (
+            <Accordion 
+              key={itemId} 
+              type="single" 
+              collapsible 
+              className="w-full"
+            >
+              <AccordionItem value={itemId} className="border-none">
+                <AccordionTrigger className="w-full py-0 hover:no-underline group">
+                  {FixedContent}
+                </AccordionTrigger>
+                <AccordionContent>
+                  <div className="mt-2 ml-4 space-y-3 border-l-2 border-muted pl-4">
+                    {tailPairs.map((pair, idx) => (
+                      <div 
+                        key={idx} 
+                        className="rounded-lg border bg-muted/30 p-3"
+                      >
+                        <div className="mb-2 flex items-center gap-2">
+                          <span className="bg-accent/10 text-accent-foreground rounded px-2 py-0.5 text-xs font-semibold">
+                            꼬리 질문
+                          </span>
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-xs font-medium text-muted-foreground">
+                            {pair.question}
+                          </p>
+                          <p className="text-sm leading-relaxed text-foreground">
+                            {pair.answer}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          );
+        })}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #107 

## ✨ 작업 내용 (Summary)
- [x] 꼬리 질문 파싱을 통해 대표 답변만 보여지도록 수정
- [x] 클릭 시 화면이 펼쳐져 꼬리 질문을 볼 수 있도록 수정
<img width="1009" height="555" alt="question" src="https://github.com/user-attachments/assets/a0fff5b5-2d68-4b29-9e3e-0ff76e9cca9b" />


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?
- [x] lint
