### PR TITLE
fix: 설문 세션 로딩 인디케이터 개선

### DIFF
--- a/src/features/survey-session/components/ChatMessage.tsx
+++ b/src/features/survey-session/components/ChatMessage.tsx
@@ -21,6 +21,13 @@ export function ChatMessage({
   ...props
 }: ChatMessageProps) {
   const isAI = message.type === 'ai';
+  // 스트리밍 중인 메시지 감지 (id가 'ai-streaming-'으로 시작)
+  const isStreaming = message.id.startsWith('ai-streaming-');
+
+  // 내용이 없는 AI 메시지는 렌더링하지 않음 (타이핑 인디케이터는 ChatMessageList에서 표시)
+  if (isAI && !message.content) {
+    return null;
+  }
 
   return (
     <div
@@ -59,8 +66,8 @@ export function ChatMessage({
           </p>
         </div>
 
-        {/* AI 메시지 피드백 버튼 */}
-        {isAI && (
+        {/* AI 메시지 피드백 버튼 - 스트리밍 중에는 숨김 */}
+        {isAI && !isStreaming && (
           <ChatFeedback
             messageContent={message.content}
             className="mt-1 ml-auto"
@@ -77,3 +84,4 @@ export function ChatMessage({
     </div>
   );
 }
+

--- a/src/features/survey-session/components/ChatMessageList.tsx
+++ b/src/features/survey-session/components/ChatMessageList.tsx
@@ -3,9 +3,9 @@
  * 스크롤 가능한 메시지 영역
  */
 
+import { Sparkles } from 'lucide-react';
 import { type ComponentProps, useEffect, useRef } from 'react';
 
-import { Spinner } from '@/components/ui/loading';
 import { cn } from '@/lib/utils';
 
 import type { ChatMessageData } from '../types';
@@ -18,11 +18,15 @@ type ChatMessageListProps = ComponentProps<'div'> & {
 
 export function ChatMessageList({
   messages,
-  isLoading,
+  isLoading: _isLoading,
   className,
   ...props
 }: ChatMessageListProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // 마지막 메시지가 사용자 메시지인지 확인 (AI 응답 대기 중)
+  const lastMessage = messages[messages.length - 1];
+  const isWaitingForAI = lastMessage?.type === 'user';
 
   // 새 메시지 시 자동 스크롤
   useEffect(() => {
@@ -44,17 +48,16 @@ export function ChatMessageList({
         />
       ))}
 
-      {/* 로딩 인디케이터 */}
-      {isLoading && (
+      {/* AI 타이핑 인디케이터 - 마지막이 사용자 메시지일 때 표시 */}
+      {isWaitingForAI && (
         <div className="flex justify-start gap-3">
           <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-full">
-            <Spinner size="sm" />
+            <Sparkles className="size-4" />
           </div>
-          <div className="bg-muted flex items-center gap-2 rounded-2xl rounded-tl-none px-4 py-3">
-            <Spinner size="sm" />
-            <span className="text-muted-foreground text-sm">
-              응답 대기 중...
-            </span>
+          <div className="bg-muted flex items-center gap-1 rounded-2xl rounded-tl-none px-4 py-3">
+            <span className="bg-foreground/60 size-2 animate-bounce rounded-full [animation-delay:0ms]" />
+            <span className="bg-foreground/60 size-2 animate-bounce rounded-full [animation-delay:150ms]" />
+            <span className="bg-foreground/60 size-2 animate-bounce rounded-full [animation-delay:300ms]" />
           </div>
         </div>
       )}
@@ -64,3 +67,4 @@ export function ChatMessageList({
     </div>
   );
 }
+

--- a/src/features/survey-session/hooks/useChatSession.ts
+++ b/src/features/survey-session/hooks/useChatSession.ts
@@ -126,8 +126,8 @@ export function useChatSession({
     onDone: (_turnNum) => {
       // 말풍선 마무리 -> 큐에 추가
       enqueueFinalize();
-      // setStreaming(false)는 큐 처리기가 담당하므로 여기선 생략 가능하나, 
-      // 큐 처리 완료 전까지 isStreaming이 true여야 하므로 store의 로직에 맡김
+      // done 이벤트 시점에 로딩 해제 (question 이벤트 없이 스트리밍만 오는 경우 대비)
+      setLoading(false);
     },
     onInterviewComplete: () => {
       enqueueFinalize();

--- a/src/pages/survey/SurveySessionPage.tsx
+++ b/src/pages/survey/SurveySessionPage.tsx
@@ -40,8 +40,6 @@ function SurveySessionPage() {
   const {
     isReady,
     isComplete,
-    isLoading,
-    isStreaming,
     error,
     messages,
     sendAnswer,
@@ -95,7 +93,7 @@ function SurveySessionPage() {
       {/* 메시지 목록 */}
       <ChatMessageList
         messages={messages}
-        isLoading={isLoading && !isStreaming}
+        isLoading={false}
         className="flex-1"
       />
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #119 

## ✨ 작업 내용 (Summary)
- [x] SSE `done` 이벤트 수신 시 `isLoading` 상태 해제하여 "응답 대기중" 상태 지속 문제 해결
- [x] 사용자 메시지 전송 시 발생하던 로딩 스피너 깜빡임 현상 제거
- [x] 마지막 메시지가 사용자 메시지일 때 점 3개(●●●) 타이핑 인디케이터 표시
- [x] 빈 AI 메시지 렌더링 방지 (`content`가 없는 AI 메시지는 `return null`)

## 🔍 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| [useChatSession.ts](cci:7://file:///Users/nobbkim/PlayProbie/client/src/features/survey-session/hooks/useChatSession.ts:0:0-0:0) | [onDone](cci:1://file:///Users/nobbkim/PlayProbie/client/src/features/survey-session/hooks/useChatSession.ts:125:4-130:5) 콜백에서 [setLoading(false)](cci:1://file:///Users/nobbkim/PlayProbie/client/src/features/survey-session/store/useChatStore.ts:409:2-409:54) 호출 추가 |
| [ChatMessageList.tsx](cci:7://file:///Users/nobbkim/PlayProbie/client/src/features/survey-session/components/ChatMessageList.tsx:0:0-0:0) | 마지막이 사용자 메시지일 때 타이핑 인디케이터 표시 |
| [ChatMessage.tsx](cci:7://file:///Users/nobbkim/PlayProbie/client/src/features/survey-session/components/ChatMessage.tsx:0:0-0:0) | 빈 AI 메시지 렌더링 방지 |
| [SurveySessionPage.tsx](cci:7://file:///Users/nobbkim/PlayProbie/client/src/pages/survey/SurveySessionPage.tsx:0:0-0:0) | 사용하지 않는 `isLoading`, `isStreaming` prop 제거 |

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
- [x] 빌드 및 테스트가 통과하였는가?

