### PR TITLE
fix: 설문 설계에서 게임 정보 누락 버그

### DIFF
--- a/src/features/survey-design/components/SurveyDesignForm.tsx
+++ b/src/features/survey-design/components/SurveyDesignForm.tsx
@@ -9,9 +9,12 @@ import {
 
 import { Button } from '@/components/ui';
 import { Form } from '@/components/ui/form';
+import { PageSpinner } from '@/components/ui/loading';
 import { Step } from '@/components/ui/Step';
+import type { GameGenre } from '@/features/game';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/lib/utils';
+import { useCurrentGameStore } from '@/stores/useCurrentGameStore';
 
 import { type SubmitResult, useFormSubmit } from '../hooks/useFormSubmit';
 import { useSurveyFormStore } from '../store/useSurveyFormStore';
@@ -38,6 +41,24 @@ function SurveyDesignForm({ className, onComplete }: SurveyDesignFormProps) {
 
   const { currentStep, goToStep, formData, updateFormData } =
     useSurveyFormStore();
+
+  // 게임 정보 가져오기
+  const { currentGame, isLoading: isLoadingGame } = useCurrentGameStore();
+
+  // 게임 정보가 있으면 survey form store에 저장
+  useEffect(() => {
+    if (currentGame) {
+      updateFormData({
+        gameName: currentGame.gameName,
+        gameGenre: currentGame.gameGenre as GameGenre[],
+        gameContext: currentGame.gameContext,
+      });
+    }
+  }, [currentGame, updateFormData]);
+
+  // 게임 정보 로딩 상태 확인
+  const hasGameInfo = Boolean(formData.gameName);
+  const isGameInfoLoading = isLoadingGame || (!hasGameInfo && !currentGame);
 
   // StrictMode 중복 제출 방지 ref
   const isSubmittingRef = useRef(false);
@@ -188,6 +209,11 @@ function SurveyDesignForm({ className, onComplete }: SurveyDesignFormProps) {
     themePriorities.length <= 3;
   const canManualNext =
     generationMethod === 'manual' && themePriorities.length >= 1;
+
+  // 게임 정보 로딩 중일 때 로딩 표시
+  if (isGameInfoLoading) {
+    return <PageSpinner message="게임 정보를 불러오는 중..." />;
+  }
 
   return (
     <div className={cn('flex flex-col gap-8', className)}>

--- a/src/features/survey-design/components/steps/StepBasicInfo.tsx
+++ b/src/features/survey-design/components/steps/StepBasicInfo.tsx
@@ -1,5 +1,4 @@
 import { Lightbulb, Rocket, Users } from 'lucide-react';
-import { useEffect } from 'react';
 import { type Control, useWatch } from 'react-hook-form';
 
 import { Badge } from '@/components/ui/Badge';
@@ -12,11 +11,9 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/Input';
-import { Spinner } from '@/components/ui/loading';
 import { Textarea } from '@/components/ui/Textarea';
-import { type GameGenre, GameGenreConfig } from '@/features/game/types';
+import { GameGenreConfig } from '@/features/game/types';
 import { cn } from '@/lib/utils';
-import { useCurrentGameStore } from '@/stores/useCurrentGameStore';
 
 import { useSurveyFormStore } from '../../store/useSurveyFormStore';
 import type { SurveyFormData, TestStage, ThemeCategory } from '../../types';
@@ -79,22 +76,8 @@ function StepBasicInfo({ control }: StepBasicInfoProps) {
   // testStage 값 감시 (테마 선택 표시 여부 결정)
   const testStage = useWatch({ control, name: 'testStage' });
 
-  // 게임 정보 가져오기
-  const { currentGame: game, isLoading: isLoadingGame } = useCurrentGameStore();
-
   // store 접근
-  const { updateFormData } = useSurveyFormStore();
-
-  // 게임 정보가 있으면 survey form store에 저장
-  useEffect(() => {
-    if (game) {
-      updateFormData({
-        gameName: game.gameName,
-        gameGenre: game.gameGenre as GameGenre[],
-        gameContext: game.gameContext,
-      });
-    }
-  }, [game, updateFormData]);
+  const { formData } = useSurveyFormStore();
 
   const getGenreLabels = (genres: string[]) => {
     return genres.map((code) => {
@@ -132,42 +115,27 @@ function StepBasicInfo({ control }: StepBasicInfoProps) {
           <CardTitle className="text-base">게임 정보</CardTitle>
         </CardHeader>
         <CardContent>
-          {isLoadingGame ? (
-            <div className="flex items-center gap-2">
-              <Spinner size="sm" />
-              <span className="text-muted-foreground">
-                게임 정보 로딩 중...
-              </span>
+          <div className="space-y-2">
+            <div>
+              <span className="text-muted-foreground text-sm">게임 이름: </span>
+              <span className="font-medium">{formData.gameName}</span>
             </div>
-          ) : game ? (
-            <div className="space-y-2">
-              <div>
-                <span className="text-muted-foreground text-sm">
-                  게임 이름:{' '}
-                </span>
-                <span className="font-medium">{game.gameName}</span>
-              </div>
-              <div className="flex flex-wrap gap-1">
-                {getGenreLabels(game.gameGenre).map((label) => (
-                  <Badge
-                    key={label}
-                    variant="secondary"
-                  >
-                    {label}
-                  </Badge>
-                ))}
-              </div>
-              {game.gameContext && (
-                <p className="text-muted-foreground text-sm">
-                  {game.gameContext}
-                </p>
-              )}
+            <div className="flex flex-wrap gap-1">
+              {getGenreLabels(formData.gameGenre ?? []).map((label) => (
+                <Badge
+                  key={label}
+                  variant="secondary"
+                >
+                  {label}
+                </Badge>
+              ))}
             </div>
-          ) : (
-            <p className="text-destructive">
-              게임을 선택해주세요. 게임 목록에서 설문 생성을 시작하세요.
-            </p>
-          )}
+            {formData.gameContext && (
+              <p className="text-muted-foreground text-sm">
+                {formData.gameContext}
+              </p>
+            )}
+          </div>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #116 

## ✨ 작업 내용 (Summary)
- [x] 설문 설계 폼 렌더링 시, `useCurrentGameStore`의 게임 정보를 `useSurveyFormStore`의 게임 정보로 바인딩하도록 변경


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

