### PR TITLE
fix: SurveyDesignForm 폼 데이터, useForm 폼 데이터, useCurrentGame 전역 상태 동기화 문제

### DIFF
--- a/src/features/survey-design/store/useSurveyFormStore.ts
+++ b/src/features/survey-design/store/useSurveyFormStore.ts
@@ -27,7 +27,7 @@ const getToday = () => new Date().toISOString().split('T')[0];
 /** 최대 스텝 인덱스 (0부터 시작) */
 const MAX_STEP_INDEX = SURVEY_FORM_STEPS.length - 1;
 
-const INITIAL_STATE = {
+export const INITIAL_STATE = {
   currentStep: 0,
   formData: {
     startedAt: getToday(),


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #116 

## ✨ 작업 내용 (Summary)
- useForm 초기화 시점과 useEffect 순서 조정
- currentGame 변경 시 form.reset()을 호출하여 폼 상태 동기화

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

