### PR TITLE
feat: 기본 생성 질문 개수를 3개에서 10개로 상향, UI/UX 및 사용성 개선

### DIFF
--- a/src/features/game/types.ts
+++ b/src/features/game/types.ts
@@ -111,6 +111,7 @@ export interface ApiGame {
   game_name: string;
   game_genre: string[];
   game_context: string;
+  extracted_elements?: string; // JSON string
   created_at: string;
   updated_at: string;
 }
@@ -159,6 +160,7 @@ export interface Game {
   gameName: string;
   gameGenre: string[];
   gameContext: string;
+  extractedElements?: string; // JSON string
   createdAt: string;
   updatedAt: string;
 }
@@ -198,6 +200,7 @@ export function toGame(api: ApiGame): Game {
     gameName: api.game_name,
     gameGenre: api.game_genre,
     gameContext: api.game_context,
+    extractedElements: api.extracted_elements,
     createdAt: api.created_at,
     updatedAt: api.updated_at,
   };

--- a/src/features/survey-design/components/SurveyDesignForm.tsx
+++ b/src/features/survey-design/components/SurveyDesignForm.tsx
@@ -274,7 +274,11 @@ function SurveyDesignForm({ className, onComplete }: SurveyDesignFormProps) {
               ) : (
                 <Button
                   type="button"
-                  disabled={isPending}
+                  disabled={
+                    isPending ||
+                    (currentStep === 2 &&
+                      !!form.formState.errors.selectedQuestionIndices)
+                  }
                   onClick={() => createHandleNext()()}
                 >
                   {isPending ? '생성 중...' : isLastStep ? '설문 생성' : '다음'}

--- a/src/features/survey-design/components/ai-question-generate/QuestionStatusBar.tsx
+++ b/src/features/survey-design/components/ai-question-generate/QuestionStatusBar.tsx
@@ -9,6 +9,7 @@ type QuestionStatusBarProps = {
   isAllSelected: boolean;
   isRegenerating?: boolean;
   onSelectAll: () => void;
+  onDeselectAll: () => void;
   onRegenerate?: () => void;
 };
 
@@ -21,20 +22,35 @@ function QuestionStatusBar({
   isAllSelected,
   isRegenerating = false,
   onSelectAll,
+  onDeselectAll,
   onRegenerate,
 }: QuestionStatusBarProps) {
   return (
     <div className="border-border bg-muted/30 flex items-center justify-between rounded-lg border px-4 py-3">
       <div className="flex items-center gap-3">
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          onClick={onSelectAll}
-          className="h-auto p-0"
-        >
-          {isAllSelected ? '전체 해제' : '전체 선택'}
-        </Button>
+        <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onSelectAll}
+              className="h-7 text-xs px-2"
+              disabled={isAllSelected}
+            >
+              전체 선택
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onDeselectAll}
+              className="h-7 text-xs px-2"
+              disabled={selectedCount === 0}
+            >
+              전체 해제
+            </Button>
+        </div>
+        <div className="h-4 w-px bg-border mx-1" />
         <span className="text-muted-foreground text-sm">
           <span className="text-foreground font-medium">{selectedCount}</span>/
           {totalCount} 선택됨

--- a/src/features/survey-design/components/steps/StepQuestionAIGenerate.tsx
+++ b/src/features/survey-design/components/steps/StepQuestionAIGenerate.tsx
@@ -24,7 +24,8 @@ function StepQuestionAIGenerate() {
     isAllSelected,
     validationError,
     handleToggle,
-    handleSelectAll,
+    selectAll,
+    deselectAll,
     handleRegenerate,
     handleAddQuestion,
   } = useQuestionGenerate();
@@ -45,7 +46,8 @@ function StepQuestionAIGenerate() {
         totalCount={totalCount}
         isAllSelected={isAllSelected}
         isRegenerating={isGenerating}
-        onSelectAll={handleSelectAll}
+        onSelectAll={selectAll}
+        onDeselectAll={deselectAll}
         onRegenerate={handleRegenerate}
       />
 

--- a/src/features/survey-design/components/steps/StepQuestionUserGenerate.tsx
+++ b/src/features/survey-design/components/steps/StepQuestionUserGenerate.tsx
@@ -26,7 +26,8 @@ function StepQuestionUserGenerate() {
     isAllSelected,
     validationError,
     handleToggle,
-    handleSelectAll,
+    selectAll,
+    deselectAll,
     handleAddQuestion,
     handleRequestFeedback,
     handleSuggestionClick,
@@ -92,7 +93,8 @@ function StepQuestionUserGenerate() {
           selectedCount={selectedCount}
           totalCount={totalCount}
           isAllSelected={isAllSelected}
-          onSelectAll={handleSelectAll}
+          onSelectAll={selectAll}
+          onDeselectAll={deselectAll}
         />
       )}
 

--- a/src/features/survey-design/hooks/useQuestionGenerate.ts
+++ b/src/features/survey-design/hooks/useQuestionGenerate.ts
@@ -61,7 +61,6 @@ function useQuestionGenerate() {
       let effectiveExtractedElements = extractedElements;
 
       if ((!effectiveGameName || !effectiveGameGenre?.length) && currentGame) {
-        console.log('[AI Questions] Fallback to global game store');
         effectiveGameName = effectiveGameName || currentGame.gameName;
         effectiveGameGenre = effectiveGameGenre?.length
           ? effectiveGameGenre
@@ -77,15 +76,6 @@ function useQuestionGenerate() {
           }
         }
       }
-
-      // 🔍 DEBUG: 필수 데이터 상태 로깅
-      console.log('[AI Questions] generateQuestions 호출됨', {
-        gameName: effectiveGameName,
-        gameGenre: effectiveGameGenre,
-        testStage,
-        extractedElements: effectiveExtractedElements,
-        shuffle: params.shuffle,
-      });
 
       if (!effectiveGameGenre?.length || !testStage) {
         throw new Error(
@@ -124,14 +114,6 @@ function useQuestionGenerate() {
     const { formData } = useSurveyFormStore.getState();
     const { gameName, gameGenre, surveyName, themePriorities } = formData;
 
-    // 🔍 DEBUG: 필수 데이터 상태 로깅
-    console.log('[AI Questions] generateQuestions 호출됨', {
-      gameName,
-      gameGenre,
-      surveyName,
-      themePriorities,
-    });
-
     // 필수 데이터 확인 (themePriorities가 1개 이상 있어야 함)
     if (
       !gameName ||
@@ -139,12 +121,6 @@ function useQuestionGenerate() {
       !surveyName ||
       !themePriorities?.length
     ) {
-      console.warn('[AI Questions] ⚠️ 필수 데이터 누락으로 스킵:', {
-        gameName: !gameName ? '❌ 없음' : '✅',
-        gameGenre: !gameGenre?.length ? '❌ 없음' : '✅',
-        surveyName: !surveyName ? '❌ 없음' : '✅',
-        themePriorities: !themePriorities?.length ? '❌ 없음' : '✅',
-      });
       return;
     }
 
@@ -180,36 +156,20 @@ function useQuestionGenerate() {
 
   // 페이지 렌더링 시 질문이 없으면 자동으로 API 호출
   useEffect(() => {
-    // 🔍 DEBUG: useEffect 상태 로깅
-    console.log('[AI Questions] useEffect 실행', {
-      isMutationPending,
-      isLocalGenerating,
-      initialGenerateRef: initialGenerateRef.current,
-      questionsLength: manager.questions.length,
-    });
-
     // 이미 생성 중이거나 초기 생성 진행 중이면 스킵
     if (isMutationPending || isLocalGenerating || initialGenerateRef.current) {
-      console.warn('[AI Questions] ⚠️ 생성 진행 중으로 스킵:', {
-        isMutationPending,
-        isLocalGenerating,
-        initialGenerateRef: initialGenerateRef.current,
-      });
       return;
     }
 
     // 질문이 있으면 스킵
     if (manager.questions.length > 0) {
-      console.warn('[AI Questions] ⚠️ 이미 질문 존재하여 스킵:', manager.questions);
       return;
     }
 
-    console.log('[AI Questions] ✅ API 호출 시작');
     initialGenerateRef.current = true;
 
     generateQuestions()
-      .catch((error) => {
-        console.error('[AI Questions] ❌ 생성 오류:', error);
+      .catch(() => {
         // Error is handled by mutation.error
       })
       .finally(() => {

--- a/src/features/survey-design/hooks/useQuestionManager.ts
+++ b/src/features/survey-design/hooks/useQuestionManager.ts
@@ -104,7 +104,8 @@ function useQuestionManager() {
 
     // Selection 핸들러
     handleToggle: selection.handleToggle,
-    handleSelectAll: selection.handleSelectAll,
+    selectAll: selection.selectAll,
+    deselectAll: selection.deselectAll,
     addQuestionAtFront: selection.addQuestionAtFront,
     removeQuestion: removeQuestionWithFeedback,
 

--- a/src/features/survey-design/hooks/useQuestionSelection.ts
+++ b/src/features/survey-design/hooks/useQuestionSelection.ts
@@ -31,11 +31,12 @@ function useQuestionSelection() {
   // Store에서 선택된 질문 인덱스 가져오기 (없거나 빈 배열이면 전체 선택)
   const selectedQuestions = useMemo(() => {
     const indices = formData.selectedQuestionIndices;
-    if (indices !== undefined && indices.length > 0) {
-      return new Set(indices);
+    // undefined일 때만 전체 선택 (초기화)
+    if (indices === undefined) {
+      return new Set(questions.map((_, i) => i));
     }
-    // 초기화 시 전체 선택
-    return new Set(questions.map((_, i) => i));
+    // 빈 배열([])도 유효한 값(모두 해제)으로 처리
+    return new Set(indices);
   }, [formData.selectedQuestionIndices, questions]);
 
   // Validation 에러 메시지 (react-hook-form에서 가져옴)
@@ -88,14 +89,15 @@ function useQuestionSelection() {
     [selectedQuestions, setSelectedQuestions]
   );
 
-  // 전체 선택/해제
-  const handleSelectAll = useCallback(() => {
-    if (selectedQuestions.size === questions.length) {
-      setSelectedQuestions(new Set());
-    } else {
-      setSelectedQuestions(new Set(questions.map((_, i) => i)));
-    }
-  }, [selectedQuestions.size, questions, setSelectedQuestions]);
+  // 전체 선택
+  const selectAll = useCallback(() => {
+    setSelectedQuestions(new Set(questions.map((_, i) => i)));
+  }, [questions, setSelectedQuestions]);
+
+  // 전체 해제
+  const deselectAll = useCallback(() => {
+    setSelectedQuestions(new Set());
+  }, [setSelectedQuestions]);
 
   // 질문 맨 앞에 추가 (선택 인덱스 재조정 포함)
   const addQuestionAtFront = useCallback(
@@ -160,7 +162,8 @@ function useQuestionSelection() {
 
     // 핸들러
     handleToggle,
-    handleSelectAll,
+    selectAll,
+    deselectAll,
     addQuestionAtFront,
     removeQuestion,
   };

--- a/src/features/survey-design/hooks/useQuestionUserGenerate.ts
+++ b/src/features/survey-design/hooks/useQuestionUserGenerate.ts
@@ -53,7 +53,8 @@ function useQuestionUserGenerate() {
 
     // 공통 핸들러 (from manager)
     handleToggle: manager.handleToggle,
-    handleSelectAll: manager.handleSelectAll,
+    selectAll: manager.selectAll,
+    deselectAll: manager.deselectAll,
     handleRequestFeedback: manager.handleRequestFeedback,
     handleSuggestionClick: manager.handleSuggestionClick,
 

--- a/src/features/survey-design/store/useSurveyFormStore.ts
+++ b/src/features/survey-design/store/useSurveyFormStore.ts
@@ -37,6 +37,7 @@ export const INITIAL_STATE = {
     themePriorities: [],
     themeDetails: {},
     versionNote: '',
+    extractedElements: {},
   },
   surveyUrl: null,
 };

--- a/src/features/survey-design/types.ts
+++ b/src/features/survey-design/types.ts
@@ -147,12 +147,12 @@ export interface ApiGenerateAiQuestionsRequest { //추가할 데이터: 핵심�
   game_context: string;
   game_genre: GameGenre[];
   test_stage: TestStage;
-  extracted_elements?: Record<string, string | null>;
   /** 테마 대분류 우선순위 (1~3개, 순서대로) */
   theme_priorities: ThemeCategory[];
   /** 테마 소분류 (대분류별 선택된 세부 테마, 선택사항) */
   theme_details?: Partial<Record<ThemeCategory, ThemeDetail[]>>;
   count: number;
+  shuffle?: boolean;
 }
 
 /** [API] POST /surveys/ai-questions Response */

--- a/src/features/survey-design/types.ts
+++ b/src/features/survey-design/types.ts
@@ -142,11 +142,12 @@ export interface CreateSurveyResponse {
 }
 
 /** [API] POST /surveys/ai-questions Request */
-export interface ApiGenerateAiQuestionsRequest {
+export interface ApiGenerateAiQuestionsRequest { //추가할 데이터: 핵심요소, 테스트단계
   game_name: string;
   game_context: string;
   game_genre: GameGenre[];
-  survey_name: string;
+  test_stage: TestStage;
+  extracted_elements?: Record<string, string | null>;
   /** 테마 대분류 우선순위 (1~3개, 순서대로) */
   theme_priorities: ThemeCategory[];
   /** 테마 소분류 (대분류별 선택된 세부 테마, 선택사항) */
@@ -284,6 +285,7 @@ export type SurveyFormData = {
   themePriorities: ThemeCategory[];
   themeDetails: Partial<Record<ThemeCategory, ThemeDetail[]>>;
   versionNote: string;
+  extractedElements: Record<string, string | null>;
 
   // Step 2: 질문 생성
   questions: string[];


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #126 

## ✨ 작업 내용 (Summary)
이번 PR에서는 AI 질문 생성 기능의 안정성을 높이고, 질문 선택 UI/UX를 개선했습니다.

**AI 질문 생성 기능 개선**
- API 요청 파라미터 최적화 (`test_stage`, `shuffle` 추가, 불필요한 필드 정리)
- 새로고침 시 게임 정보가 유지되도록 Fallback 로직 추가
- 기본 생성 질문 개수를 3개에서 10개로 상향
- `StepBasicInfo`에서 게임 정보 폼 데이터 자동 연동 처리

**UI/UX 및 사용성 개선**
- 질문 전체 선택/해제 버튼 분리 및 UI 개선
- 전체 해제 시 자동으로 다시 전체 선택되는 로직 오류 수정
- 질문 미선택 시 '설문 생성' 버튼 비활성화 (필수 선택 로직 적용)

**코드 품질**
- `useQuestionGenerate`, `useQuestionSelection` 훅 리팩토링 및 린트 경고 해결
- 불필요한 콘솔 로그 제거 및 프로덕션 빌드 대응

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?
