### PR TITLE
fix: 설문 전 테스터 정보 입력 창 패싱 이슈

### DIFF
--- a/src/features/game-streaming-session/components/StreamCompletionDialog.tsx
+++ b/src/features/game-streaming-session/components/StreamCompletionDialog.tsx
@@ -27,7 +27,7 @@ export function StreamCompletionDialog({
     // SurveySessionPage 경로는 /surveys/session/sessions/:sessionUuid
     // surveyUuid는 state로 전달해야 하지만, window.location.href로는 state 전달 불가
     // 따라서 query param으로 전달
-    window.location.href = `${baseUrl}/surveys/session/sessions/${sessionUuid}?surveyUuid=${surveyUuid}`;
+    window.location.href = `${baseUrl}/surveys/session/${surveyUuid}?sessionUuid=${sessionUuid}`;
   };
 
   return (

--- a/src/pages/survey/SurveySessionStartPage.tsx
+++ b/src/pages/survey/SurveySessionStartPage.tsx
@@ -126,14 +126,17 @@ function SurveySessionStartPage() {
       const { session, sse_url: sseUrl } = response.result;
 
       // 세션 정보를 state로 전달하면서 리다이렉트
-      navigate(`/surveys/session/sessions/${session.session_uuid}`, {
-        replace: true,
-        state: {
-          surveyUuid: session.survey_uuid,
-          sessionUuid: session.session_uuid,
-          sseUrl: sseUrl,
-        },
-      });
+      navigate(
+        `/surveys/session/sessions/${session.session_uuid}?surveyUuid=${session.survey_uuid}`,
+        {
+          replace: true,
+          state: {
+            surveyUuid: session.survey_uuid,
+            sessionUuid: session.session_uuid,
+            sseUrl: sseUrl,
+          },
+        }
+      );
     } catch {
       // 에러 로깅은 생략
       setError('세션 생성에 실패했습니다. 잠시 후 다시 시도해주세요.');


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #135 

## ✨ 작업 내용 (Summary)
- `StreamCompletionDialog` 페이지 컴포넌트에서 `SurveySessionStartPage` 페이지 컴포넌트로 이동하도록 변경


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

