### PR TITLE
fix: 스트리밍 데이터 수집 안정성 개선

### DIFF
--- a/src/features/game-streaming-session/components/StreamCompletionDialog.tsx
+++ b/src/features/game-streaming-session/components/StreamCompletionDialog.tsx
@@ -35,7 +35,11 @@ export function StreamCompletionDialog({
       open={open}
       onOpenChange={onOpenChange}
     >
-      <DialogContent showCloseButton={false}>
+      <DialogContent
+        showCloseButton={false}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>게임 플레이가 종료되었습니다</DialogTitle>
           <DialogDescription>

--- a/src/features/game-streaming-session/hooks/stream/useGameStream.ts
+++ b/src/features/game-streaming-session/hooks/stream/useGameStream.ts
@@ -32,22 +32,25 @@ export type {
   UseGameStreamReturn,
 } from './use-game-stream.types';
 
+const highlightEnabled = true;
+// const highlightEnabled = import.meta.env.VITE_ENABLE_HIGHLIGHT === 'true';
+
+// Mock 스트림 사용 여부
+const useMockStream =
+  import.meta.env.DEV && import.meta.env.VITE_MOCK_STREAM === 'true';
+
 /**
  * WebRTC 스트리밍 연결
  */
-export function useGameStream(
-  options: UseGameStreamOptions
-): UseGameStreamReturn {
-  const {
-    surveyUuid,
-    onConnected,
-    onDisconnected,
-    onError,
-    inputLogging = {},
-    streamHealth: streamHealthOptions = {},
-    segmentRecording = {},
-  } = options;
-
+export function useGameStream({
+  surveyUuid,
+  onConnected,
+  onDisconnected,
+  onError,
+  inputLogging = {},
+  streamHealth: streamHealthOptions = {},
+  segmentRecording = {},
+}: UseGameStreamOptions): UseGameStreamReturn {
   const {
     enabled: inputLoggingEnabled = true,
     batchSize = 50,
@@ -60,8 +63,6 @@ export function useGameStream(
     onStatusChange: onStreamHealthChange,
   } = streamHealthOptions;
 
-  const highlightEnabled = true;
-  // const highlightEnabled = import.meta.env.VITE_ENABLE_HIGHLIGHT === 'true';
   const {
     enabled: segmentRecordingEnabled = highlightEnabled,
     maxStorageBytes: segmentRecordingMaxStorageBytes,
@@ -71,10 +72,6 @@ export function useGameStream(
   } = segmentRecording;
 
   const { toast } = useToast();
-
-  // Mock 스트림 사용 여부
-  const useMockStream =
-    import.meta.env.DEV && import.meta.env.VITE_MOCK_STREAM === 'true';
 
   const [isGameReady, setIsGameReady] = useState(false);
   const [uploadSessionId, setUploadSessionId] = useState<string | null>(null);
@@ -127,11 +124,14 @@ export function useGameStream(
     if (!isConnected) {
       return null;
     }
+
     if (streamHealth.health === 'UNSTABLE') {
       return 0;
     }
+
     const availableIncomingBitrate =
       streamHealth.metrics.availableIncomingBitrate;
+
     if (
       typeof availableIncomingBitrate === 'number' &&
       Number.isFinite(availableIncomingBitrate) &&
@@ -148,6 +148,7 @@ export function useGameStream(
     streamHealth.health,
     streamHealth.metrics.availableIncomingBitrate,
   ]);
+
   const { enqueueSegment: enqueueUploadSegment, flush: flushUploadWorker } =
     useUploadWorker({
       enabled: uploadWorkerEnabled,

--- a/src/features/game-streaming-session/hooks/stream/useStreamHealth.ts
+++ b/src/features/game-streaming-session/hooks/stream/useStreamHealth.ts
@@ -63,10 +63,36 @@ function readStreamHealthMetrics(
       }
     }
 
-    if (report.type === 'inbound-rtp' && report.kind === 'video') {
-      packetsLost += report.packetsLost || 0;
-      packetsReceived += report.packetsReceived || 0;
-      hasPacketStats = true;
+    if (report.type === 'inbound-rtp') {
+      const mediaType =
+        (report as { kind?: string; mediaType?: string }).kind ??
+        (report as { mediaType?: string }).mediaType;
+      const shouldInclude = mediaType ? mediaType === 'video' : true;
+      if (shouldInclude) {
+        packetsLost += report.packetsLost || 0;
+        packetsReceived += report.packetsReceived || 0;
+        hasPacketStats = true;
+      }
+    }
+
+    if (report.type === 'remote-inbound-rtp') {
+      const mediaType =
+        (report as { kind?: string; mediaType?: string }).kind ??
+        (report as { mediaType?: string }).mediaType;
+      const shouldInclude = mediaType ? mediaType === 'video' : true;
+      if (shouldInclude) {
+        const packetsLostValue =
+          typeof report.packetsLost === 'number' ? report.packetsLost : 0;
+        const packetsReceivedValue =
+          typeof report.packetsReceived === 'number' ? report.packetsReceived : 0;
+        packetsLost += packetsLostValue;
+        packetsReceived += packetsReceivedValue;
+        hasPacketStats = true;
+      }
+      if (typeof report.roundTripTime === 'number') {
+        const rttMs = report.roundTripTime * 1000;
+        currentRtt = currentRtt == null ? rttMs : Math.max(currentRtt, rttMs);
+      }
     }
   });
 

--- a/src/features/game-streaming-session/workers/upload-worker.types.ts
+++ b/src/features/game-streaming-session/workers/upload-worker.types.ts
@@ -32,6 +32,13 @@ export type UploadWorkerCommand =
 
 export type UploadWorkerEvent =
   | {
+      type: 'segment-processing';
+      payload: {
+        localSegmentId: string;
+        startedAt: string;
+      };
+    }
+  | {
       type: 'segment-uploaded';
       payload: {
         localSegmentId: string;

--- a/src/features/game-streaming-session/workers/upload.worker.ts
+++ b/src/features/game-streaming-session/workers/upload.worker.ts
@@ -319,6 +319,13 @@ async function processQueue(): Promise<void> {
 
   processing = true;
   queue.markInFlight(nextItem.key);
+  postEvent({
+    type: 'segment-processing',
+    payload: {
+      localSegmentId: nextItem.key,
+      startedAt: new Date().toISOString(),
+    },
+  });
 
   try {
     const result = await performUpload(nextItem.payload);

--- a/src/pages/play/QueuePage.tsx
+++ b/src/pages/play/QueuePage.tsx
@@ -2,7 +2,7 @@
  * 테스터 대기열 페이지
  *
  * 게임 스트리밍 입장 전 대기열과 예상 대기시간을 표시합니다.
- * 일정 시간(기본 5초) 후 스트리밍 페이지로 이동합니다.
+ * 일정 시간(기본 3초) 후 스트리밍 페이지로 이동합니다.
  */
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -16,7 +16,7 @@ import {
 } from '@/features/game-streaming-session';
 
 /** 입장까지의 대기 시간 (초) */
-const DEFAULT_WAIT_SECONDS = 5;
+const DEFAULT_WAIT_SECONDS = 3;
 
 export default function QueuePage() {
   const { surveyUuid } = useParams<{ surveyUuid: string }>();

--- a/src/pages/play/StreamingPlayPage.tsx
+++ b/src/pages/play/StreamingPlayPage.tsx
@@ -4,7 +4,7 @@
  * 테스터가 게임을 스트리밍으로 플레이하는 페이지입니다.
  * 밝은 테마의 게임 스트리밍 UI를 제공합니다.
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
@@ -161,14 +161,6 @@ export default function StreamingPlayPage() {
     return () => clearInterval(timer);
   }, [isConnected]);
 
-  // 시간 만료 시 자동 종료
-  useEffect(() => {
-    if (remainingTime === 0 && isConnected) {
-      handleDisconnect();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [remainingTime, isConnected]);
-
   // 연결 시작 핸들러 (수동 재시도용)
   const handleConnect = async () => {
     if (!surveyUuid || isConnecting || isConnected) return;
@@ -185,7 +177,7 @@ export default function StreamingPlayPage() {
   };
 
   // 연결 종료 핸들러
-  const handleDisconnect = () => {
+  const handleDisconnect = useCallback(() => {
     if (!surveyUuid || !sessionUuid) return;
 
     // 수동 종료 플래그 설정
@@ -230,7 +222,21 @@ export default function StreamingPlayPage() {
         },
       }
     );
-  };
+  }, [
+    surveyUuid,
+    sessionUuid,
+    signalMutation,
+    terminateMutation,
+    disconnect,
+    toast,
+  ]);
+
+  // 시간 만료 시 자동 종료
+  useEffect(() => {
+    if (remainingTime === 0 && isConnected) {
+      handleDisconnect();
+    }
+  }, [remainingTime, isConnected, handleDisconnect]);
 
   // 에러 상태 처리
   if (!surveyUuid) {


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #135 

## ✨ 작업 내용 (Summary)
- **업로드 중복 방지 및 안정성 강화 (Upload Stability & Deduplication)**
  - `pending` 업로드 항목에 `processing` 상태 및 소유자(Owner) 기록 필드 추가
  - Service Worker/Shared Worker 클레임 및 Stale 상태 복구 로직으로 중복 업로드 원천 차단
  - 워커의 처리 시작/실패 이벤트가 상태에 즉시 반영되도록 갱신 로직 개선
  - WebRTC 통계 파싱 로직 보강으로 네트워크 판단 정확도 향상 및 불필요한 업로드 차단 완화

- **UX 개선 (User Experience)**
  - 스트리밍 종료 다이얼로그 `StreamCompletionDialog`가 백드롭 클릭이나 ESC 키로 닫히지 않도록 수정 (오동작 방지)
  - 완료 모달 유지 및 대기열 이동 타이밍 조정


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

