### PR TITLE
fix: AI 질문 생성 시 잘못된 게임 데이터 참조 문제 수정

### DIFF
--- a/src/features/survey-design/types.ts
+++ b/src/features/survey-design/types.ts
@@ -153,6 +153,8 @@ export interface ApiGenerateAiQuestionsRequest { //추가할 데이터: 핵심�
   theme_details?: Partial<Record<ThemeCategory, ThemeDetail[]>>;
   count: number;
   shuffle?: boolean;
+  extracted_elements?: Record<string, string>;
+  game_uuid?: string;
 }
 
 /** [API] POST /surveys/ai-questions Response */


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #139 

## ✨ 작업 내용 (Summary)
- 신규 게임 질문 생성 시 이전 게임의 정보가 잘못 반영되는 버그 수정
- 현재 작성 중인 게임 이름과 데이터가 일치할 때만 기존 정보를 참조하도록 개선
- AI API 요청 시 와 를 명시적으로 전달하여 생성 정확도 향상


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

