### PR TITLE
fix: Service Worker 인증 헤더 누락 문제 수정

### DIFF
--- a/src/features/game-streaming-session/api/post-input-logs.ts
+++ b/src/features/game-streaming-session/api/post-input-logs.ts
@@ -14,12 +14,14 @@ import type { ApiInputLogsUploadRequest, InputLog } from '../types';
  * @param segmentId - 세그먼트 ID
  * @param videoUrl - 세그먼트 영상 URL
  * @param logs - 입력 로그 배열
+ * @param authToken - 인증 토큰 (선택)
  */
 export async function postInputLogs(
   sessionId: string,
   segmentId: string,
   videoUrl: string,
-  logs: InputLog[]
+  logs: InputLog[],
+  authToken?: string
 ): Promise<void> {
   const requestBody: ApiInputLogsUploadRequest = {
     session_id: sessionId,
@@ -28,13 +30,18 @@ export async function postInputLogs(
     logs,
   };
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (authToken) {
+    headers['Authorization'] = `Bearer ${authToken}`;
+  }
+
   const response = await fetch(
     `${API_BASE_URL}/sessions/${sessionId}/replay/logs`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(requestBody),
     }
   );

--- a/src/features/game-streaming-session/api/post-presigned-url.ts
+++ b/src/features/game-streaming-session/api/post-presigned-url.ts
@@ -9,15 +9,21 @@ import { toPresignedUrl } from '../types';
 
 export async function postPresignedUrl(
   sessionId: string,
-  request: ApiPresignedUrlRequest
+  request: ApiPresignedUrlRequest,
+  authToken?: string
 ): Promise<{ segmentId: string; s3Url: string; expiresIn: number }> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (authToken) {
+    headers['Authorization'] = `Bearer ${authToken}`;
+  }
+
   const response = await fetch(
     `${API_BASE_URL}/sessions/${sessionId}/replay/presigned-url`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(request),
     }
   );

--- a/src/features/game-streaming-session/api/post-upload-complete.ts
+++ b/src/features/game-streaming-session/api/post-upload-complete.ts
@@ -8,19 +8,25 @@ import type { ApiSegmentUploadCompleteRequest } from '../types';
 
 export async function postUploadComplete(
   sessionId: string,
-  segmentId: string
+  segmentId: string,
+  authToken?: string
 ): Promise<void> {
   const requestBody: ApiSegmentUploadCompleteRequest = {
     segment_id: segmentId,
   };
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (authToken) {
+    headers['Authorization'] = `Bearer ${authToken}`;
+  }
+
   const response = await fetch(
     `${API_BASE_URL}/sessions/${sessionId}/replay/upload-complete`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(requestBody),
     }
   );

--- a/src/features/game-streaming-session/hooks/upload/useUploadWorker.ts
+++ b/src/features/game-streaming-session/hooks/upload/useUploadWorker.ts
@@ -292,6 +292,16 @@ export function useUploadWorker({
 
     workerRef.current = worker;
 
+    // Worker에 인증 토큰 전달
+    const token = localStorage.getItem('accessToken');
+    if (token) {
+      const tokenMessage: UploadWorkerCommand = {
+        type: 'set-auth-token',
+        payload: { token },
+      };
+      worker.postMessage(tokenMessage);
+    }
+
     const handleMessage = (event: MessageEvent<UploadWorkerEvent>) => {
       const message = event.data;
 

--- a/src/features/game-streaming-session/workers/upload-worker.types.ts
+++ b/src/features/game-streaming-session/workers/upload-worker.types.ts
@@ -24,6 +24,12 @@ export type UploadWorkerCommand =
       };
     }
   | {
+      type: 'set-auth-token';
+      payload: {
+        token: string;
+      };
+    }
+  | {
       type: 'flush';
     }
   | {

--- a/src/features/game-streaming-session/workers/upload.worker.ts
+++ b/src/features/game-streaming-session/workers/upload.worker.ts
@@ -162,6 +162,7 @@ let streamingActive = true;
 let processing = false;
 let timerId: ReturnType<typeof setTimeout> | null = null;
 let activeAbortController: AbortController | null = null;
+let authToken: string | null = null;
 const rateLimiter = new UploadRateLimiter();
 
 function postEvent(event: UploadWorkerEvent): void {
@@ -256,7 +257,8 @@ async function performUpload(task: UploadTask): Promise<{
         video_start_ms: task.segment.start_media_time,
         video_end_ms: task.segment.end_media_time,
         content_type: task.contentType,
-      }
+      },
+      authToken ?? undefined
     );
 
     task.remoteSegmentId = backendSegmentId;
@@ -280,7 +282,11 @@ async function performUpload(task: UploadTask): Promise<{
   }
 
   if (!task.completeNotified && task.remoteSegmentId) {
-    await postUploadComplete(task.sessionId, task.remoteSegmentId);
+    await postUploadComplete(
+      task.sessionId,
+      task.remoteSegmentId,
+      authToken ?? undefined
+    );
 
     task.completeNotified = true;
   }
@@ -291,7 +297,8 @@ async function performUpload(task: UploadTask): Promise<{
         task.sessionId,
         task.remoteSegmentId,
         task.s3Url,
-        task.logs
+        task.logs,
+        authToken ?? undefined
       );
     }
     task.logsUploaded = true;
@@ -433,6 +440,10 @@ workerContext.onmessage = (event: MessageEvent<UploadWorkerCommand>) => {
     }
     case 'reset': {
       resetQueue();
+      break;
+    }
+    case 'set-auth-token': {
+      authToken = message.payload.token;
       break;
     }
     default: {


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #135 

## ✨ 작업 내용 (Summary)
- upload-sw.js에서 Authorization 헤더 없이 API 호출하던 문제 해결
- postMessage로 토큰을 안전하게 SW에 전달 (URL 노출 방지)
- getApiHeaders() 헬퍼 함수로 모든 API 요청에 인증 헤더 추가

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

