### PR TITLE
feat: 설문 대시보드 정보 업데이트 시 깜빡임 문제 해결을 위한 silent 모드 추가

### DIFF
--- a/src/pages/survey/SurveyAnalyticsPage.tsx
+++ b/src/pages/survey/SurveyAnalyticsPage.tsx
@@ -77,13 +77,13 @@ function SurveyAnalyticsPage() {
     filters.preferGenre !== null;
 
   // SSE 구독 및 업데이트 시 리패치 트리거
-  // 필터가 적용된 상태면 filtered만, 아니면 unfiltered도 함께 refetch
+  // silent: true로 호출하여 기존 데이터 유지 + 로딩 UI 없이 백그라운드 갱신
   useAnalyticsSubscription(effectiveSurveyUuid, () => {
-    refetchFiltered();
+    refetchFiltered({ silent: true });
     // 필터가 없는 경우에만 unfiltered도 refetch
     // (필터 분석 완료 SSE는 필터 데이터와 관련 없음)
     if (!hasActiveFilters) {
-      refetchUnfiltered();
+      refetchUnfiltered({ silent: true });
     }
   });
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #155 

## ✨ 작업 내용 (Summary)
- [x] useQuestionAnalysis 훅에 silent 옵션 추가하여 백그라운드 갱신 지원
- [x] SSE refresh 이벤트 시 기존 데이터 유지하며 로딩 UI 없이 갱신
- [x] 필터 변경 시에만 로딩 화면 표시하도록 분리

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

