### PR TITLE
fix: web worker 업로드 실패 토스트 알림 제거

### DIFF
--- a/src/features/game-streaming-session/hooks/stream/useGameStream.ts
+++ b/src/features/game-streaming-session/hooks/stream/useGameStream.ts
@@ -6,8 +6,6 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useToast } from '@/hooks/useToast';
-
 import {
   UPLOAD_RATE_CAP_BPS,
   UPLOAD_RATE_FALLBACK_BPS,
@@ -50,8 +48,6 @@ export function useGameStream({
   streamHealth: streamHealthOptions = {},
   segmentRecording = {},
 }: UseGameStreamOptions): UseGameStreamReturn {
-  const { toast } = useToast();
-
   const {
     enabled: inputLoggingEnabled = true,
     batchSize = 50,
@@ -156,18 +152,12 @@ export function useGameStream({
       uploadRateBps,
       streamingActive: isConnected,
       onError: (error) => {
-        toast({
-          variant: 'destructive',
-          title: '업로드 처리 실패',
-          description: error.message,
-        });
+        // eslint-disable-next-line no-console
+        console.error('[Upload] 업로드 처리 실패:', error.message);
       },
       onSegmentFailed: (_segmentId, reason) => {
-        toast({
-          variant: 'destructive',
-          title: '세그먼트 업로드 실패',
-          description: reason,
-        });
+        // eslint-disable-next-line no-console
+        console.error('[Upload] 세그먼트 업로드 실패:', _segmentId, reason);
       },
     });
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #157 

## ✨ 작업 내용 (Summary)
- Web Worker 업로드 실패 시, 토스트 알림 제거
  - 세그먼트 업로드 실패 시 pending 상태로 전환하여 추후에 Shared/Service Worker가 처리


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

